### PR TITLE
Fix compilation of match types under the Scala 3.5.x 

### DIFF
--- a/narr/shared/src/main/scala/narr/package.scala
+++ b/narr/shared/src/main/scala/narr/package.scala
@@ -35,13 +35,13 @@ package object narr {
 
   type TypedArrayPrimitive = Byte | Short | Int | Float | Double
 
-  type ArrayElementType[T <: NativeTypedArray | NativeArray[T]] = T match
+  type ArrayElementType[T <: NativeTypedArray | NativeArray[?]] = T match
     case ByteArray => Byte
     case ShortArray => Short
     case IntArray => Int
     case FloatArray => Float
     case DoubleArray => Double
-    case NativeArray[T] => T
+    case NativeArray[t] => t
 
   type NArray[T] = narr.native.NArray[T]
 


### PR DESCRIPTION
Fix compilation of match types under the Scala 3.5.x changes to match types based on Scala 3 Open Community Build failure in https://github.com/scala/scala3/issues/20299
 